### PR TITLE
chore: set .nvmrc (lts/carbon)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v8.17.0
+lts/carbon


### PR DESCRIPTION
Zmienia `.nvmrc` na codename `lts/carbon`.

konwersja z 'v8.17.0' -> codename.

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.