### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ isLetter('abba'); // => false
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.